### PR TITLE
fix(ci): target glibc for address sanitizer fuzzing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -119,7 +119,7 @@ jobs:
           tool: cargo-fuzz@0.13.1
       - name: Run fuzz target
         working-directory: fuzz
-        run: cargo +nightly fuzz run "${{ matrix.target }}" -- -max_total_time=120
+        run: cargo +nightly fuzz run "${{ matrix.target }}" --target x86_64-unknown-linux-gnu -- -max_total_time=120
       - name: Upload fuzz failures
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
cargo-fuzz inherited a musl target on GitHub's runner, which is incompatible with ASan. Explicitly target x86_64-unknown-linux-gnu for the Linux nightly fuzz matrix.

Validated with actionlint, cargo fmt, clippy, and 506 workspace tests.