### PR TITLE
chore(release): prepare v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,33 @@
 
 All notable changes to this project are documented in this file.
 
-## [Unreleased]
+## [0.5.4] - 2026-09-09
+
+### CI
+- Sync main into develop
+- Harden workspace publication
+- Harden validation and releases
 
 ### Chores
-- Update provider fallback metadata and record the remaining automation protocol work
-- Anchor the prioritized feature backlog at the relevant implementation seams
+- Update provider fallback and automation TODOs
 
 ### Documentation
-- Synchronize runtime documentation with current behavior
+- Sync runtime documentation with current behavior
+- Record prioritized feature backlog
+- Capture post-release handoff
+- Refresh release handoff state
+
+### Fixes
+- Use current taskit command groups
+- Satisfy MSRV clippy formatting
+- Serialize process-wide cwd tests
+- Use supported protoc version
+- Install runtime tools and resolve dependency audit
+- Use immutable release checkout ref
+- Harden release and test resilience
+- Allow cargo fuzz binary fallback
+- Scope cargo fuzz fallback
+- Target glibc for address sanitizer fuzzing
 
 ## [0.5.3] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
 ## [0.5.4] - 2026-09-09
 
 ### CI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "looprs"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "looprs-cli"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "colored",
@@ -2151,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "looprs-core"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2167,11 +2167,11 @@ dependencies = [
 
 [[package]]
 name = "looprs-macros"
-version = "0.5.3"
+version = "0.5.4"
 
 [[package]]
 name = "looprs-tui"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "crossterm 0.28.1",
@@ -5181,7 +5181,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xtask"
-version = "0.5.3"
+version = "0.5.4"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"
@@ -25,10 +25,10 @@ anyhow = "^1.0.103" #unified
 chrono = { version = "^0.4.44", features = ["serde"] } #unified
 colored = "^2.2.0" #unified
 dirs = "^5.0.1" #unified
-looprs = { path = "crates/looprs", version = "^0.5.3" } #unified
-looprs-core = { path = "crates/looprs-core", version = "^0.5.3" } #unified
-looprs-macros = { path = "crates/looprs-macros", version = "^0.5.3" } #unified
-looprs-tui = { path = "crates/looprs-tui", version = "^0.5.3" } #unified
+looprs = { path = "crates/looprs", version = "^0.5.4" } #unified
+looprs-core = { path = "crates/looprs-core", version = "^0.5.4" } #unified
+looprs-macros = { path = "crates/looprs-macros", version = "^0.5.4" } #unified
+looprs-tui = { path = "crates/looprs-tui", version = "^0.5.4" } #unified
 miette = { version = "^7.6.0", features = ["fancy"] } #unified
 proptest = "^1.10.0" #unified
 serde = { version = "^1.0.228", features = ["derive"] } #unified

--- a/cliff.toml
+++ b/cliff.toml
@@ -35,6 +35,8 @@ commit_preprocessors = [
 ]
 
 commit_parsers = [
+  { message = "^Merge pull request", skip = true },
+  { message = "^chore\\(release\\)", skip = true },
   { message = "^feat", group = "Features" },
   { message = "^fix", group = "Fixes" },
   { message = "^refactor", group = "Refactoring" },
@@ -43,6 +45,7 @@ commit_parsers = [
   { message = "^test", group = "Tests" },
   { message = "^build", group = "Build" },
   { message = "^ci", group = "CI" },
+  { message = "^flow", group = "CI" },
   { message = "^chore", group = "Chores" },
   { message = "^revert", group = "Reverts" },
   { message = ".*", group = "Other" },


### PR DESCRIPTION
## Summary
- Bump all publishable workspace crates to version 0.5.4.
- Add curated 0.5.4 release notes and refine git-cliff grouping for release automation.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace`
- [x] `cargo nextest run --workspace` (506 passed)
- [x] `cargo clippy --workspace -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Version 0.5.4 is now available.

- **Bug Fixes**
  - Improved task command-group handling.
  - Corrected release checkout references and tool installation behavior.
  - Stabilized serialized working-directory tests and fuzzing workflows.
  - Updated protocol compiler handling and minimum-supported Rust formatting.

- **Documentation**
  - Synchronized runtime documentation.
  - Recorded feature backlog and handoff information.

- **CI**
  - Strengthened continuous integration and workspace publication workflows.
  - Improved changelog categorization for automated release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->