### PR TITLE
fix(release): use registry index for visibility checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,8 +158,7 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           registry_has() {
-            curl --fail --silent --show-error "https://crates.io/api/v1/crates/$1/$VERSION" >/dev/null 2>&1 &&
-              CARGO_HOME="${RUNNER_TEMP}/registry-check" cargo +1.88.0 info "$1@$VERSION" >/dev/null 2>&1
+            CARGO_HOME="${RUNNER_TEMP}/registry-check" cargo +1.88.0 info "$1@$VERSION" --registry crates-io >/dev/null 2>&1
           }
 
           wait_for_crate() {


### PR DESCRIPTION
## Summary
- Replace the crates.io HTTP API visibility probe, which returns HTTP 403 on GitHub runners.
- Use `cargo info --registry crates-io` as the single authoritative publication check so interrupted releases resume idempotently.

## Test plan
- [x] Reproduced registry lookup with a clean `CARGO_HOME`
- [x] `actionlint .github/workflows/release.yml`
- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace`
- [x] `cargo nextest run --workspace` (506 passed)
- [x] `cargo clippy --workspace -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation by checking crate availability directly through the package registry tooling.
  * Removed reliance on a separate crates.io API request during publishing checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->