### PR TITLE
fix(release): prevent wrapped tag auth headers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,7 +361,8 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if [[ -z "$remote_commit" ]]; then
             git tag -a "v${VERSION}" "${{ github.sha }}" -m "Release v${VERSION}"
-            git -c http.extraheader="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64)" \
+            auth_header=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
+            git -c http.extraheader="AUTHORIZATION: basic ${auth_header}" \
               push "https://github.com/${GITHUB_REPOSITORY}.git" "v${VERSION}"
           fi
 


### PR DESCRIPTION
## Summary
- Strip line wrapping from the base64-encoded GitHub token authorization header used for release tag pushes.
- Prevent libcurl from rejecting malformed multi-line HTTP headers during release finalization.

## Test plan
- [x] `actionlint .github/workflows/release.yml`
- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace`
- [x] `cargo nextest run --workspace` (506 passed)
- [x] `cargo clippy --workspace -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process so authenticated tag pushes use a consistently formatted credential value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->